### PR TITLE
moved filepath manipulation into getTemplate

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,10 +76,6 @@ var _engine = {
     },
     handleCache: function(filepath) {
         assert(filepath, 'filepath cannot be null');
-        filepath = path.resolve(this.options.root, filepath);
-        if (path.extname(filepath) === '') {
-            filepath += this.options.extname;
-        }
 
         return this.getTemplate(filepath)
             .then((html) => {
@@ -88,6 +84,10 @@ var _engine = {
             });
     },
     getTemplate: function(filepath) {
+        filepath = path.resolve(this.options.root, filepath);
+        if (path.extname(filepath) === '') {
+            filepath += this.options.extname;
+        }
         return new Promise(function(resolve, reject) {
             fs.readFile(filepath, 'utf8', function(err, html) {
                 err ? reject(err) : resolve(html);


### PR DESCRIPTION
This allows overridden versions of getTemplate to receive the filepath raw, and do whatever they want to with it.  For me, I'm just doing a lookup of the template name in Mongo.  I didn't want c:\whatever prepended and .liquid appended.  I needed to just see the raw template name as supplied in the include tag.