### PR TITLE
Interpolate bracket access

### DIFF
--- a/src/lexical.js
+++ b/src/lexical.js
@@ -5,7 +5,7 @@ var quoteBalanced = new RegExp(`(?:${singleQuoted.source}|${doubleQuoted.source}
 
 var number = /(?:-?\d+\.?\d*|\.?\d+)/;
 var bool = /true|false/;
-var identifier = /[a-zA-Z_$][a-zA-Z_$0-9]*/;
+var identifier = /[a-zA-Z_\-$][a-zA-Z_$0-9\-]*/;
 var subscript = new RegExp(`\\[(?:\\d+|${identifier.source}(?:\\.${identifier.source})*)\\]`);
 
 var quoted = new RegExp(`(?:${singleQuoted.source}|${doubleQuoted.source})`);

--- a/src/lexical.js
+++ b/src/lexical.js
@@ -6,7 +6,7 @@ var quoteBalanced = new RegExp(`(?:${singleQuoted.source}|${doubleQuoted.source}
 var number = /(?:-?\d+\.?\d*|\.?\d+)/;
 var bool = /true|false/;
 var identifier = /[a-zA-Z_$][a-zA-Z_$0-9]*/;
-var subscript = /\[\d+\]/;
+var subscript = new RegExp(`\\[(?:\\d+|${identifier.source}(?:\\.${identifier.source})*)\\]`);
 
 var quoted = new RegExp(`(?:${singleQuoted.source}|${doubleQuoted.source})`);
 var literal = new RegExp(`(?:${quoted.source}|${bool.source}|${number.source})`);
@@ -70,7 +70,7 @@ function parseLiteral(str) {
 
 module.exports = {
     quoted, number, bool, literal, filter,
-    hash, hashCapture,
+    hash, hashCapture, subscript,
     range, rangeCapture, 
     identifier, value, quoteBalanced, operators,
     quotedLine, numberLine, boolLine, rangeLine, literalLine, filterLine, tagLine,

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,3 +1,5 @@
+const lexical = require('./lexical');
+
 var Scope = {
     safeGet: function(str) {
         var i;
@@ -57,9 +59,15 @@ function setPropertyByPath(obj, path, val) {
     return obj[path] = val;
 }
 
+function resolveHashKeys() {
+  return `.${getPropertyByPath(this, arguments[1])}`;
+}
+
 function getPropertyByPath(obj, path) {
     if (path instanceof String || typeof path === 'string') {
-        var paths = path.replace(/\[/g, '.').replace(/\]/g, '').split('.');
+        var resolveRE = new RegExp(`\\[(\\d+|${lexical.identifier.source}(?:\\.${lexical.identifier.source})*)\\]`);
+        var pathWithResolvedBrackets = path.replace(resolveRE, resolveHashKeys.bind(obj));
+        var paths = pathWithResolvedBrackets.split('.');
         paths.forEach(p => obj = obj && obj[p]);
         return obj;
     }

--- a/src/strftime.js
+++ b/src/strftime.js
@@ -381,6 +381,10 @@ var strftime = function(d, format) {
     var output = '';
     var remaining = format;
 
+    if(d == 'now') {
+      d = new Date();
+    }
+
     while (true) {
         var r = /%./g;
         var results = r.exec(remaining);


### PR DESCRIPTION
There's probably a better way to do this, but it seems to work in a pinch. 
Previously, `getPropertyByPath` was replacing bracket access with `.`, then splitting. However, this doesn't allow it to resolve nested keys:
```
collections[settings.frontpage].products
```
was being treated as 
```
collections.settings.frontpage.products
```
Anyways, hope this helps 😄 