### PR TITLE
Support create variables on the filter line.

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -36,7 +36,9 @@ module.exports = function(options) {
 
             var args = [];
             while(match = valueRE.exec(argList.trim())){
-                args.push(match[0]);
+                var v = match[0];
+                var re = new RegExp(`${v}\\s*:`, 'g');
+                re.test(match.input) ? args.push(`'${v}'`) : args.push(v);
             }
 
             this.name = name;

--- a/src/lexical.js
+++ b/src/lexical.js
@@ -37,7 +37,7 @@ var rangeLine = new RegExp(`^${rangeCapture.source}$`);
 var integerLine = new RegExp(`^${integer.source}$`);
 
 // filter related
-var valueList = new RegExp(`${value.source}(\\s*,\\s*${value.source})*`);
+var valueList = new RegExp(`${value.source}(\\s*,?:?\\s*${value.source})*`);
 var filter = new RegExp(`${identifier.source}(?:\\s*:\\s*${valueList.source})?`, 'g');
 var filterCapture = new RegExp(`(${identifier.source})(?:\\s*:\\s*(${valueList.source}))?`);
 var filterLine = new RegExp(`^${filterCapture.source}$`);

--- a/test/filters.js
+++ b/test/filters.js
@@ -327,4 +327,9 @@ describe('filters', function() {
         it('should encode <space>',
             () => test('{{ "Tetsuro Takara" | url_encode }}', 'Tetsuro%20Takara'));
     });
+
+    describe('obj_test', function() {
+        liquid.registerFilter('obj_test', (...v) => v.join(','));
+        it('should support object', () => test('{{ "a" | obj_test: k1: "v1", k2: "v2" }}', 'a,k1,v1,k2,v2'));
+    });
 });

--- a/test/filters.js
+++ b/test/filters.js
@@ -329,7 +329,9 @@ describe('filters', function() {
     });
 
     describe('obj_test', function() {
-        liquid.registerFilter('obj_test', (...v) => v.join(','));
+        liquid.registerFilter('obj_test', function() {
+            return Array.prototype.slice.call(arguments).join(',');
+        });
         it('should support object', () => test('{{ "a" | obj_test: k1: "v1", k2: "v2" }}', 'a,k1,v1,k2,v2'));
     });
 });

--- a/test/lexical.js
+++ b/test/lexical.js
@@ -11,7 +11,9 @@ describe('lexical', function() {
         lexical.filterLine.test('foo: a, "b"').should.equal(true);
         lexical.filterLine.test('abs | another').should.equal(false);
         lexical.filterLine.test('join: "," | another').should.equal(false);
+        lexical.filterLine.test('obj_test: k1: "v1", k2: "v2"').should.equal(true);
     });
+
     it('should test boolean literal', function() {
         lexical.isLiteral('true').should.equal(true);
         lexical.isLiteral('TrUE').should.equal(true);


### PR DESCRIPTION
Custom Filter
```js
liquid.registerFilter('obj_test', (...v) => v.join(','));
```

Liquid

```twig
{{ "a" | obj_test: k1: "v1", k2: "v2" }}
```

Output

```
a,k1,v1,k2,v2
```

A fly in the ointment is the filter returns the arguments are array, need array2object processing:

array [key,value] to object {key: value} 

```js
liquid.registerFilter('obj_test', (v, ...args) => {
  var obj = {};
  for (var i = 0; i < args.length; i++) {
    var arg = args[i];
    if (i % 2 == 0) {
      obj[arg] = 1 + i;
    }
  }
  for (var arg in obj) {
    obj[arg] = args[obj[arg]] || '';
  }
  // v, obj
  // console.log(v, obj);
  // ...
  return;
});
```