### PR TITLE
support multiline tags

### DIFF
--- a/src/lexical.js
+++ b/src/lexical.js
@@ -27,7 +27,7 @@ var hash = new RegExp(`(?:${identifier.source})\\s*:\\s*(?:${value.source})`);
 var hashCapture = new RegExp(`(${identifier.source})\\s*:\\s*(${value.source})`, 'g');
 
 // full match
-var tagLine = new RegExp(`^\\s*(${identifier.source})\\s*(.*)\\s*$`);
+var tagLine = new RegExp(`^\\s*(${identifier.source})\\s*([\\s\\S]*)\\s*$`);
 var literalLine = new RegExp(`^${literal.source}$`, 'i');
 var variableLine = new RegExp(`^${variable.source}$`);
 var numberLine = new RegExp(`^${number.source}$`);

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -9,7 +9,7 @@ function parse(html, filepath, options) {
     html = whiteSpaceCtrl(html, options);
 
     var tokens = [];
-    var syntax = /({%-?(.*?)-?%})|({{(.*?)}})/g;
+    var syntax = /({%-?([\s\S]*?)-?%})|({{([\s\S]*?)}})/g;
     var result, htmlFragment, token;
     var lastMatchEnd = 0, lastMatchBegin = -1, parsedLinesCount = 0;
 

--- a/test/tag.js
+++ b/test/tag.js
@@ -62,9 +62,9 @@ describe('tag', function() {
             });
             token = {
                 type: 'tag',
-                value: 'foo aa:foo bb: arr[0] cc: 2.3 dd:bar.coo',
+                value: 'foo aa:foo bb: arr[0] cc: 2.3\ndd:bar.coo',
                 name: 'foo',
-                args: 'aa:foo bb: arr[0] cc: 2.3 dd:bar.coo'
+                args: 'aa:foo bb: arr[0] cc: 2.3\ndd:bar.coo'
             };
         });
         it('should call tag.render with scope', function() {

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -56,6 +56,21 @@ describe('tokenizer', function() {
             expect(tokens[3].type).to.equal('html');
             expect(tokens[3].raw).to.equal('  \n ');
         });
+        it('should handle multiple lines tag', function() {
+            var html = '{%foo\na:a\nb:1.23\n%}';
+            var tokens = parse(html);
+            expect(tokens.length).to.equal(1);
+            expect(tokens[0].type).to.equal('tag');
+            expect(tokens[0].args).to.equal('a:a\nb:1.23');
+            expect(tokens[0].raw).to.equal('{%foo\na:a\nb:1.23\n%}');
+        });
+        it('should handle multiple lines output', function() {
+            var html = '{{foo\n|\date:\n"%Y-%m-%d"\n}}';
+            var tokens = parse(html);
+            expect(tokens.length).to.equal(1);
+            expect(tokens[0].type).to.equal('output');
+            expect(tokens[0].raw).to.equal('{{foo\n|\date:\n"%Y-%m-%d"\n}}');
+        });
     });
     describe('whitespace control', function() {
         it('should not strip by default', function() {


### PR DESCRIPTION
It would be great that shopify-liquid could handle multiline tags for example

{% tag d1:'a'
           d2:'b'
           d3:'c'
%}

This is useful if we have very long lines of parameters/attributes passed to tag

In JS there isn't "dotall" modifier but this can be solved using [\s\S] modifier to replace ".".

See more http://stackoverflow.com/questions/1068280/javascript-regex-multiline-flag-doesnt-work
