### PR TITLE
Remove unused `stop` and `skip` from `forloop` object

### DIFF
--- a/tags/for.js
+++ b/tags/for.js
@@ -60,9 +60,7 @@ module.exports = function (liquid) {
           last: i === length - 1,
           length: length,
           rindex: length - i,
-          rindex0: length - i - 1,
-          stop: false,
-          skip: false
+          rindex0: length - i - 1
         }
         return ctx
       })


### PR DESCRIPTION
The `stop` and `skip` properties of `forloop` are unused since this commit: 951225fb75141a235b4d2e52de4b8dda585a1ccd