### PR TITLE
Iterate keys of object when used with `for...in` loop

### DIFF
--- a/src/util/underscore.js
+++ b/src/util/underscore.js
@@ -95,6 +95,15 @@ function isObject (value) {
 }
 
 /*
+ * Checks if value's prototype is Object or undefined.
+ * @param {any} value The value to check.
+ * @return {Boolean} Returns true if value is a plain object, else false.
+ */
+function isPlainObject(value) {
+  return value && !value.constructor || value.constructor === Object
+}
+
+/*
  * A function to create flexibly-numbered lists of integers,
  * handy for each and map loops. start, if omitted, defaults to 0; step defaults to 1.
  * Returns a list of integers from start (inclusive) to stop (exclusive),
@@ -119,6 +128,7 @@ function range (start, stop, step) {
 exports.isString = isString
 exports.isArray = isArray
 exports.isObject = isObject
+exports.isPlainObject = isPlainObject
 exports.isError = isError
 
 exports.range = range

--- a/tags/for.js
+++ b/tags/for.js
@@ -1,6 +1,7 @@
 const Liquid = require('..')
 const lexical = Liquid.lexical
 const mapSeries = require('../src/util/promise.js').mapSeries
+const isPlainObject = require('../src/util/underscore.js').isPlainObject
 const RenderBreakError = Liquid.Types.RenderBreakError
 const assert = require('../src/util/assert.js')
 const re = new RegExp(`^(${lexical.identifier.source})\\s+in\\s+` +
@@ -38,10 +39,10 @@ module.exports = function (liquid) {
     render: function (scope, hash) {
       var collection = Liquid.evalExp(this.collection, scope)
 
-      if (isObject(collection)) {
+      if (isPlainObject(collection)) {
         collection = Object.keys(collection)
       }
-      if (isEmpty(collection)) {
+      if (!Array.isArray(collection) || !collection.length) {
         return liquid.renderer.renderTemplates(this.elseTemplates, scope)
       }
 
@@ -91,19 +92,4 @@ module.exports = function (liquid) {
       }).then(() => html)
     }
   })
-}
-
-function isObject(collection) {
-  if (collection) {
-    const ctr = collection.constructor
-    return ctr === Object || ctr == null
-  }
-  return false
-}
-
-function isEmpty(collection) {
-  if (Array.isArray(collection)) {
-    return !collection.length
-  }
-  return true
 }

--- a/tags/for.js
+++ b/tags/for.js
@@ -38,8 +38,10 @@ module.exports = function (liquid) {
     render: function (scope, hash) {
       var collection = Liquid.evalExp(this.collection, scope)
 
-      if (!Array.isArray(collection) ||
-                (Array.isArray(collection) && collection.length === 0)) {
+      if (isObject(collection)) {
+        collection = Object.keys(collection)
+      }
+      if (isEmpty(collection)) {
         return liquid.renderer.renderTemplates(this.elseTemplates, scope)
       }
 
@@ -89,4 +91,19 @@ module.exports = function (liquid) {
       }).then(() => html)
     }
   })
+}
+
+function isObject(collection) {
+  if (collection) {
+    const ctr = collection.constructor
+    return ctr === Object || ctr == null
+  }
+  return false
+}
+
+function isEmpty(collection) {
+  if (Array.isArray(collection)) {
+    return !collection.length
+  }
+  return true
 }


### PR DESCRIPTION
This allows `for...in` loops to work with `{}` or `Object.create(null)`.

I added `isObject` and `isEmpty` for cleaner `if` statements. I can remove those if you prefer.